### PR TITLE
Replaced `exprots` with `exports` in valid_input.js file

### DIFF
--- a/valid_input.js
+++ b/valid_input.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-exprots.valid_input = function(substrings, text){
+exports.valid_input = function(substrings, text){
     assert(typeof text=='string');
     assert(/^[\x20-\x7f]*$/.test(text));
     assert(Array.isArray(substrings));


### PR DESCRIPTION
Referencing #1.
